### PR TITLE
Add pre-commit GitHub Actions workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,36 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+jobs:
+  run:
+    name: Run pre-commit hooks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            build-essential \
+            clang \
+            clang-tidy \
+            cmake
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run pre-commit
+        run: pre-commit run --all-files


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow to run the repository's pre-commit hooks
- install required build and Python dependencies so the hooks execute successfully

## Testing
- not run (GitHub Actions workflow only)


------
https://chatgpt.com/codex/tasks/task_e_68ce65064130832a944a027de0161f3b