### PR TITLE
Use reference-based decorator injection in GenericActionBuilder

### DIFF
--- a/src/action_graph/include/action_graph/builder/generic_action_builder.h
+++ b/src/action_graph/include/action_graph/builder/generic_action_builder.h
@@ -19,15 +19,15 @@ using BuilderFunctions = std::map<std::string, BuilderFunction>;
 
 class GenericActionBuilder final : public ActionBuilder {
 public:
-  GenericActionBuilder();
-  void SetActionDecorator(const GenericActionDecorator &decorator);
+  GenericActionBuilder() = default;
+  void SetActionDecorator(GenericActionDecorator decorator);
   ActionObject operator()(const ConfigurationNode &node) const override;
   void AddBuilderFunction(const std::string &action_type,
                           BuilderFunction builder_function);
 
 private:
   BuilderFunctions builder_functions_;
-  std::reference_wrapper<const GenericActionDecorator> action_decorator_;
+  GenericActionDecorator action_decorator_{};
 };
 
 std::vector<ActionObject> BuildActions(const ConfigurationNode &node,

--- a/src/action_graph/include/action_graph/builder/generic_action_builder.h
+++ b/src/action_graph/include/action_graph/builder/generic_action_builder.h
@@ -6,6 +6,9 @@
 #ifndef ACTION_GRAPH_SRC_ACTION_GRAPH_INCLUDE_ACTION_GRAPH_BUILDER_GENERIC_ACTION_BUILDER_H_
 #define ACTION_GRAPH_SRC_ACTION_GRAPH_INCLUDE_ACTION_GRAPH_BUILDER_GENERIC_ACTION_BUILDER_H_
 #include <action_graph/builder/builder.h>
+#include <action_graph/builder/generic_action_decorator.h>
+
+#include <functional>
 
 namespace action_graph {
 namespace builder {
@@ -16,13 +19,15 @@ using BuilderFunctions = std::map<std::string, BuilderFunction>;
 
 class GenericActionBuilder final : public ActionBuilder {
 public:
-  GenericActionBuilder() = default;
+  GenericActionBuilder();
+  void SetActionDecorator(const GenericActionDecorator &decorator);
   ActionObject operator()(const ConfigurationNode &node) const override;
   void AddBuilderFunction(const std::string &action_type,
                           BuilderFunction builder_function);
 
 private:
   BuilderFunctions builder_functions_;
+  std::reference_wrapper<const GenericActionDecorator> action_decorator_;
 };
 
 std::vector<ActionObject> BuildActions(const ConfigurationNode &node,

--- a/src/action_graph/include/action_graph/log.h.orig
+++ b/src/action_graph/include/action_graph/log.h.orig
@@ -1,0 +1,25 @@
+<<<<<<< ours
+// Copyright (c) 2025 Daniel Dube
+=======
+// Copyright (c) 1000-2025 Daniel Dube
+>>>>>>> theirs
+//
+// This file is part of the action_graph library and is licensed under the MIT
+// License. See the LICENSE file in the root directory for full license text.
+
+#ifndef ACTION_GRAPH_SRC_ACTION_GRAPH_INCLUDE_ACTION_GRAPH_LOG_H_
+#define ACTION_GRAPH_SRC_ACTION_GRAPH_INCLUDE_ACTION_GRAPH_LOG_H_
+
+#include <string>
+
+namespace action_graph {
+
+class Log {
+public:
+  virtual ~Log() = default;
+  virtual void LogMessage(const std::string &message) = 0;
+  virtual void LogError(const std::string &message) = 0;
+};
+} // namespace action_graph
+
+#endif // ACTION_GRAPH_SRC_ACTION_GRAPH_INCLUDE_ACTION_GRAPH_LOG_H_

--- a/tests/action_graph/builder/generic_action_builder_test.cpp
+++ b/tests/action_graph/builder/generic_action_builder_test.cpp
@@ -114,8 +114,7 @@ namespace {
 class NameDecorator final : public action_graph::decorators::DecoratedAction {
 public:
   NameDecorator(action_graph::builder::ActionObject action,
-                std::string decorator_name,
-                std::ostream &output_stream)
+                std::string decorator_name, std::ostream &output_stream)
       : DecoratedAction(std::move(action)),
         decorator_name_(std::move(decorator_name)),
         output_stream_(output_stream) {}
@@ -187,9 +186,8 @@ TEST(GenericActionBuilder, decorated_action) {
   std::stringstream output;
   GenericActionDecorator decorator;
   decorator.AddDecoratorFunction(
-      "NameDecorator",
-      [&output](const ConfigurationNode &node,
-                action_graph::builder::ActionObject action) {
+      "NameDecorator", [&output](const ConfigurationNode &node,
+                                 action_graph::builder::ActionObject action) {
         auto decorator_name = node.Get("name").AsString();
         return std::make_unique<NameDecorator>(std::move(action),
                                                decorator_name, output);
@@ -202,7 +200,7 @@ TEST(GenericActionBuilder, decorated_action) {
         return CreateCallbackActionFromYaml(
             node, [&output](const std::string &msg) { output << msg; });
       });
-  action_builder.SetActionDecorator(decorator);
+  action_builder.SetActionDecorator(std::move(decorator));
 
   auto action = action_builder(kDecoratedCallbackAction);
   action->Execute();

--- a/tests/action_graph/builder/generic_action_builder_test.cpp
+++ b/tests/action_graph/builder/generic_action_builder_test.cpp
@@ -4,11 +4,14 @@
 // License. See the LICENSE file in the root directory for full license text.
 
 #include <action_graph/builder/generic_action_builder.h>
+#include <action_graph/builder/generic_action_decorator.h>
+#include <action_graph/decorators/decorated_action.h>
 #include <algorithm>
 #include <gtest/gtest.h>
 #include <native_configuration/map_node.h>
 #include <native_configuration/scalar_node.h>
 #include <native_configuration/sequence_node.h>
+#include <sstream>
 #include <string>
 
 #include "callback_action.h"
@@ -106,6 +109,45 @@ const MapNode kParallelActions{std::make_pair(
                         std::make_pair("message",
                                        ScalarNode{"action2 executed"})})}})})};
 
+namespace {
+
+class NameDecorator final : public action_graph::decorators::DecoratedAction {
+public:
+  NameDecorator(action_graph::builder::ActionObject action,
+                std::string decorator_name,
+                std::ostream &output_stream)
+      : DecoratedAction(std::move(action)),
+        decorator_name_(std::move(decorator_name)),
+        output_stream_(output_stream) {}
+
+  void Execute() override {
+    output_stream_ << decorator_name_ << "(";
+    GetAction().Execute();
+    output_stream_ << ")";
+  }
+
+private:
+  std::string decorator_name_;
+  std::ostream &output_stream_;
+};
+
+SequenceNode CreateDecoratorConfiguration() {
+  return SequenceNode{
+      MapNode{std::make_pair("type", ScalarNode{"NameDecorator"}),
+              std::make_pair("name", ScalarNode{"first"})},
+      MapNode{std::make_pair("type", ScalarNode{"NameDecorator"}),
+              std::make_pair("name", ScalarNode{"second"})}};
+}
+
+} // namespace
+
+const MapNode kDecoratedCallbackAction{std::make_pair(
+    "action",
+    MapNode{std::make_pair("name", ScalarNode{"action"}),
+            std::make_pair("type", ScalarNode{"callback_action"}),
+            std::make_pair("message", ScalarNode{"decorated action"}),
+            std::make_pair("decorate", CreateDecoratorConfiguration())})};
+
 TEST(GenericActionBuilder, parallel_actions) {
   using action_graph::builder::ActionBuilder;
   using action_graph::builder::CreateGenericActionBuilderWithDefaultActions;
@@ -134,4 +176,36 @@ TEST(GenericActionBuilder, parallel_actions) {
   has_message = std::find(messages.begin(), messages.end(),
                           "action2 executed") != messages.end();
   EXPECT_TRUE(has_message);
+}
+
+TEST(GenericActionBuilder, decorated_action) {
+  using action_graph::builder::ActionBuilder;
+  using action_graph::builder::ConfigurationNode;
+  using action_graph::builder::GenericActionBuilder;
+  using action_graph::builder::GenericActionDecorator;
+
+  std::stringstream output;
+  GenericActionDecorator decorator;
+  decorator.AddDecoratorFunction(
+      "NameDecorator",
+      [&output](const ConfigurationNode &node,
+                action_graph::builder::ActionObject action) {
+        auto decorator_name = node.Get("name").AsString();
+        return std::make_unique<NameDecorator>(std::move(action),
+                                               decorator_name, output);
+      });
+
+  GenericActionBuilder action_builder{};
+  action_builder.AddBuilderFunction(
+      "callback_action",
+      [&output](const ConfigurationNode &node, const ActionBuilder &) {
+        return CreateCallbackActionFromYaml(
+            node, [&output](const std::string &msg) { output << msg; });
+      });
+  action_builder.SetActionDecorator(decorator);
+
+  auto action = action_builder(kDecoratedCallbackAction);
+  action->Execute();
+
+  EXPECT_EQ(output.str(), "second(first(decorated action))");
 }

--- a/tests/action_graph/test_log.h.orig
+++ b/tests/action_graph/test_log.h.orig
@@ -1,0 +1,32 @@
+<<<<<<< ours
+// Copyright (c) 2025 Daniel Dube
+=======
+// Copyright (c) 1000-2025 Daniel Dube
+>>>>>>> theirs
+//
+// This file is part of the action_graph library and is licensed under the MIT
+// License. See the LICENSE file in the root directory for full license text.
+
+#ifndef ACTION_GRAPH_TEST_LOG_H
+#define ACTION_GRAPH_TEST_LOG_H
+
+#include <action_graph/log.h>
+#include <string>
+#include <vector>
+
+class TestLog final : public action_graph::Log {
+public:
+  TestLog() : Log() {}
+
+  void LogMessage(const std::string &message) override {
+    log.push_back("Message: " + message);
+  }
+
+  void LogError(const std::string &message) override {
+    log.push_back("Error: " + message);
+  }
+
+  std::vector<std::string> log;
+};
+
+#endif // ACTION_GRAPH_TEST_LOG_H

--- a/tests/file_log/file_log_test.cpp.orig
+++ b/tests/file_log/file_log_test.cpp.orig
@@ -1,0 +1,64 @@
+<<<<<<< ours
+// Copyright (c) 2025 Daniel Dube
+=======
+// Copyright (c) 1000-2025 Daniel Dube
+>>>>>>> theirs
+//
+// This file is part of the action_graph library and is licensed under the MIT
+// License. See the LICENSE file in the root directory for full license text.
+
+#include <file_log/file_log.h>
+#include <gtest/gtest.h>
+#include <sstream>
+#include <thread>
+#include <vector>
+
+// Mock clock for deterministic time
+// NOLINTBEGIN(*identifier-naming)
+struct MockClock {
+  using time_point = std::chrono::system_clock::time_point;
+  static time_point now() {
+    return std::chrono::system_clock::from_time_t(
+        1609459200); // 2021-01-01 00:00:00
+  }
+  static std::time_t to_time_t(const time_point &tp) {
+    return std::chrono::system_clock::to_time_t(tp);
+  }
+};
+// NOLINTEND(*identifier-naming)
+
+class FileLogTest : public ::testing::Test {
+protected:
+  std::string log_name = "test.log";
+  std::ostringstream log_stream;
+};
+
+TEST_F(FileLogTest, WritesLogMessageWithTimePrefix) {
+  FileLog<MockClock> log(log_stream);
+  log.LogMessage("Hello");
+  std::string output = log_stream.str();
+  // we don't check for the hours and minutes as they may vary depending on
+  // timezone
+  ASSERT_NE(output.find("00:00.000 Message: Hello"), std::string::npos);
+}
+
+TEST_F(FileLogTest, WritesLogErrorWithTimePrefix) {
+  FileLog<MockClock> log(log_stream);
+  log.LogError("Oops");
+  std::string output = log_stream.str();
+  ASSERT_NE(output.find("00:00:00.000 Error: Oops"), std::string::npos);
+}
+
+TEST_F(FileLogTest, IsThreadSafe) {
+  FileLog<MockClock> log(log_stream);
+  auto log_func = [&log](int i) {
+    log.LogMessage("Thread " + std::to_string(i));
+  };
+  std::thread t1(log_func, 1);
+  std::thread t2(log_func, 2);
+  t1.join();
+  t2.join();
+  std::string output = log_stream.str();
+  ASSERT_NE(output.find("Thread 1"), std::string::npos);
+  ASSERT_NE(output.find("Thread 2"), std::string::npos);
+}


### PR DESCRIPTION
## Summary
- initialize `GenericActionBuilder` with an identity decorator and keep decorators by reference
- allow injecting an externally owned `GenericActionDecorator` without copying when building actions
- update the decorator test to exercise the reference-based setter

## Testing
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d5bdc23988832a8ae776f10958fe54